### PR TITLE
ci: evitar 409 de artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
           poetry run python -m diff_risk_dashboard.cli examples/sample_apv.json -f md -o _intel/report.md
           ls -l _intel/report.md && head -n 5 _intel/report.md
       - name: Upload sample report
+      if: matrix.python-version == '3.12'
         if: always()
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
El artifact se sube sólo en 3.12; el smoke ya pasa en ambas.