### PR TITLE
ci(release): enable manual/tag releases (GHCR, guarded PyPI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,42 @@
 name: release
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag a publicar (e.g. v0.4.31)'
+        required: false
   push:
-    tags: ['v*']
+    tags:
+      - 'v*'
+
 permissions:
   contents: write
   packages: write
+
+env:
+  TAG: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+
 jobs:
   build-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - uses: actions/setup-python@v5
         with: { python-version: '3.12' }
-      - name: Build
+      - name: Build sdist/wheel
         run: |
           python -m pip install -U pip build
           python -m build
       - uses: actions/upload-artifact@v4
         with: { name: dist, path: dist/* }
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/v') && secrets.PYPI_API_TOKEN != ''
+      - name: Publish to PyPI (guarded)
+        if: ${{ env.TAG != '' && startsWith(env.TAG, 'v') && secrets.PYPI_API_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
   publish-ghcr:
     needs: build-publish
     runs-on: ubuntu-latest
@@ -41,4 +54,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.TAG || github.ref_name }}


### PR DESCRIPTION
Release manual/tag; PyPI solo con token.