### PR TITLE
ci(release): solid GHCR + guarded PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,44 +2,26 @@ name: release
 on:
   push:
     tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to publish (v*)'
-        required: false
+
 permissions:
-  contents: write
+  contents: read
   packages: write
 
-jobs:
-  build-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
-      - name: Build
-        run: |
-          python -m pip install -U pip build
-          python -m build
-      - uses: actions/upload-artifact@v4
-        with: { name: dist, path: dist/* }
-      - name: Publish to PyPI (guarded)
-        if: startsWith(github.ref, 'refs/tags/v') && secrets.PYPI_API_TOKEN != ''
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
-  publish-ghcr:
-    needs: build-publish
+jobs:
+  ghcr:
+    name: Publish GHCR
     runs-on: ubuntu-latest
-    permissions: { contents: read, packages: write }
     steps:
       - uses: actions/checkout@v4
       - name: Compute image name (lowercase)
         shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -48,5 +30,27 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64
           push: true
+          provenance: false
           tags: ${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${{ github.ref_name }}
+
+  pypi:
+    name: Publish PyPI (guarded)
+    if: ${{ secrets.PYPI_API_TOKEN != '' }}
+    needs: ghcr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - name: Build sdist/wheel
+        run: |
+          python -m pip install -U pip build
+          python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Solo tags v*. GHCR con buildx/amd64. PyPI solo si hay token.